### PR TITLE
Check for slack API errors

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -163,7 +163,8 @@ def send_slack_notification(notification_text, error=True):
     }
 
     try:
-        requests.post('https://slack.com/api/chat.postMessage', json_message)
+        slack_response = requests.post('https://slack.com/api/chat.postMessage', json_message)
+        slack_response.raise_for_status()
     except requests.RequestException as err:
         logger.error('Post to Slack API encountered an error')
         logger.error(err, exc_info=True)


### PR DESCRIPTION
By default `requests` does not throw exceptions even if a non 2xx response is received. This fixes that